### PR TITLE
save earliest and latest violations to category

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,6 @@
 class Category < ActiveRecord::Base
   validates :name, presence: true
   validates :count, presence: true
+  validates :earliest_violation_date, presence: true
+  validates :latest_violation_date, presence: true
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,3 @@
 class CategorySerializer < ActiveModel::Serializer
-  attributes :name, :count
+  attributes :name, :count, :earliest_violation_date, :latest_violation_date
 end

--- a/db/migrate/20160607231520_create_categories.rb
+++ b/db/migrate/20160607231520_create_categories.rb
@@ -5,6 +5,8 @@ class CreateCategories < ActiveRecord::Migration
     create_table :categories do |t|
       t.integer :count
       t.citext :name
+      t.string :earliest_violation_date
+      t.string :latest_violation_date
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,8 +20,10 @@ ActiveRecord::Schema.define(version: 20160607231520) do
   create_table "categories", force: :cascade do |t|
     t.integer  "count"
     t.citext   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "earliest_violation_date"
+    t.string   "latest_violation_date"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   create_table "violations", force: :cascade do |t|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -19,7 +19,15 @@ namespace :import do
     categories = Violation.pluck(:violation_category).uniq
 
     categories.each do |category|
-      category = Category.create(name: category, count: Violation.where(violation_category: category).count)
+      category_violations = Violation.where(violation_category: category)
+
+      category = Category.create(
+        name: category,
+        count: category_violations.count,
+        earliest_violation_date: category_violations.order(:violation_date).first.violation_date,
+        latest_violation_date: category_violations.order(:violation_date).last.violation_date
+      )
+
       if category.save
         puts "Created Category"
       else

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,4 +3,6 @@ require 'rails_helper'
 RSpec.describe Category, type: :model do
   it { should validate_presence_of :name }
   it { should validate_presence_of :count }
+  it { should validate_presence_of :earliest_violation_date }
+  it { should validate_presence_of :latest_violation_date }
 end

--- a/spec/requests/api/v1/category_index_spec.rb
+++ b/spec/requests/api/v1/category_index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "GET categories index" do
   it "returns a list of all categories" do
-    Category.create(name: "Trash", count: 2)
-    Category.create(name: "Water", count: 3)
-    Category.create(name: "Bugs", count: 4)
+    Category.create(name: "Trash", count: 2, earliest_violation_date: "2012-01-03", latest_violation_date: "2012-12-12")
+    Category.create(name: "Water", count: 3, earliest_violation_date: "2012-01-04", latest_violation_date: "2012-12-13")
+    Category.create(name: "Bugs", count: 4, earliest_violation_date: "2012-01-05", latest_violation_date: "2012-12-14")
 
     get "/api/v1/categories"
 
@@ -14,7 +14,9 @@ RSpec.describe "GET categories index" do
 
     expect(category).to eq ({
       "name" => "Bugs",
-      "count" => 4
+      "count" => 4,
+      "earliest_violation_date" => "2012-01-05",
+      "latest_violation_date" => "2012-12-14"
       })
   end
 end


### PR DESCRIPTION
I'm working with data on building violations and seek to create a timeline of the earliest and latest dates of violation for each of the 9 categories of violation (18 points on the timeline in total).

This PR adds attributes for the earliest and latest violation dates to a Category model. I'm reading the data in from CSV, and I have quite a bit of logic in my import rake task. Wondering if this is the best place to put it?
